### PR TITLE
Support scikit-image 0.18

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import cv2
-from skimage.measure import compare_ssim as sk_cpt_ssim
+from skimage.metrics import structural_similarity as sk_cpt_ssim
 
 
 import os


### PR DESCRIPTION
Latest scikit-image 0.18 has removed some deprecated functions, in particular `compare_ssim` https://scikit-image.org/docs/0.18.x/api_changes.html.
This PR fixes the API change, an alternative is to set specific versions in requirements.txt.