### PR TITLE
Add Docker environment & web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Open in RunwayML Badge](https://open-app.runwayml.com/gh-badge.svg)](https://open-app.runwayml.com/?model=akhaliq/stylized-neural-painting)
 
-[Preprint](<https://arxiv.org/abs/2011.08114>) | [Project Page](<https://jiupinjia.github.io/neuralpainter/>)  | [Colab Runtime 1](<https://colab.research.google.com/drive/1XwZ4VI12CX2v9561-WD5EJwoSTJPFBbr?usp=sharing/>)  | [Colab Runtime 2](<https://colab.research.google.com/drive/1ch_41GtcQNQT1NLOA21vQJ_rQOjjv9D8?usp=sharing/>) 
+[Preprint](<https://arxiv.org/abs/2011.08114>) | [Project Page](<https://jiupinjia.github.io/neuralpainter/>)  | [Colab Runtime 1](<https://colab.research.google.com/drive/1XwZ4VI12CX2v9561-WD5EJwoSTJPFBbr?usp=sharing/>)  | [Colab Runtime 2](<https://colab.research.google.com/drive/1ch_41GtcQNQT1NLOA21vQJ_rQOjjv9D8?usp=sharing/>)  | [Demo and Docker image on Replicate](https://replicate.ai/jiupinjia/stylized-neural-painting-oil)
 
 ## Official PyTorch implementation of the preprint paper "Stylized Neural Painting", accepted to CVPR 2021.
 

--- a/cog.yml
+++ b/cog.yml
@@ -1,0 +1,23 @@
+build:
+  gpu: true
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+  python_version: "3.8"
+  python_packages:
+    - "imageio==2.9.0"
+    - "numpy==1.21.1"
+    - "scikit-image==0.18.2"
+    - "opencv-python==4.5.3.56"
+    - "ipython==7.21.0"
+    - "Pillow==8.3.1"
+    - "matplotlib==3.1.3"
+    - "scipy==1.4.1"
+    - "scikit-image==0.18.2"
+    - "opencv-contrib-python==4.5.3.56"
+    - "gdown==3.13.0"
+    - "runway-python==0.6.1"
+    - "torchvision==0.9.0"
+    - "torch==1.8.0"
+
+predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,132 @@
+import argparse
+import tempfile
+from pathlib import Path
+
+import cog
+import imageio
+import matplotlib.pyplot as plt
+import torch
+import torch.optim as optim
+from painter import *
+
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        self.args = self.set_args()
+
+    @cog.input("image", type=Path, help="input image")
+    @cog.input(
+        "canvas_color",
+        type=str,
+        options=["black", "white"],
+        default="black",
+        help="canvas color",
+    )
+    @cog.input("max_strokes", type=int, default=500, help="max number of strokes")
+    @cog.input(
+        "output_type",
+        type=str,
+        options=["png", "gif"],
+        default="png",
+        help="output the final painting or gif with each intermediate stroke",
+    )
+    def predict(self, image, canvas_color="black", max_strokes=500, output_type="png"):
+        self.args.img_path = str(image)
+        self.args.canvas_color = canvas_color
+        self.args.max_m_strokes = max_strokes
+
+        pt = Painter(args=self.args)
+        final_image, all_images = optimize_painter(pt, self.args, output_type)
+
+        out_path = Path(tempfile.mkdtemp()) / "out.png"
+        if output_type == "png":
+            plt.imsave(str(out_path), final_image)
+        else:
+            out_path = Path(tempfile.mkdtemp()) / "out.gif"
+            imageio.mimwrite(str(out_path), all_images, duration=0.02)
+        return out_path
+
+    def set_args(self):
+        parser = argparse.ArgumentParser(description="STYLIZED NEURAL PAINTING")
+        args = parser.parse_args(args=[])
+        args.renderer = (
+            "oilpaintbrush"  # [watercolor, markerpen, oilpaintbrush, rectangle]
+        )
+        args.canvas_size = 512  # size of the canvas for stroke rendering'
+        args.keep_aspect_ratio = (
+            False  # whether to keep input aspect ratio when saving outputs
+        )
+        args.m_grid = 5  # divide an image to m_grid x m_grid patches
+        args.max_divide = 5  # divide an image up-to max_divide x max_divide patches
+        args.beta_L1 = 1.0  # weight for L1 loss
+        args.with_ot_loss = False  # set True for imporving the convergence by using optimal transportation loss, but will slow-down the speed
+        args.beta_ot = 0.1  # weight for optimal transportation loss
+        args.net_G = "zou-fusion-net"  # renderer architecture
+        args.renderer_checkpoint_dir = (
+            "./checkpoints_G_oilpaintbrush"  # dir to load the pretrained neu-renderer
+        )
+        args.lr = 0.005  # learning rate for stroke searching
+        args.output_dir = "./output"  # dir to save painting results
+        args.disable_preview = (
+            True  # disable cv2.imshow, for running remotely without x-display
+        )
+        return args
+
+
+def optimize_painter(pt, args, output_type):
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    pt._load_checkpoint()
+    pt.net_G.eval()
+
+    pt.initialize_params()
+    pt.x_ctt.requires_grad = True
+    pt.x_color.requires_grad = True
+    pt.x_alpha.requires_grad = True
+    utils.set_requires_grad(pt.net_G, False)
+
+    pt.optimizer_x = optim.RMSprop([pt.x_ctt, pt.x_color, pt.x_alpha], lr=pt.lr)
+
+    print("begin to draw...")
+    pt.step_id = 0
+    for pt.anchor_id in range(0, pt.m_strokes_per_block):
+        pt.stroke_sampler(pt.anchor_id)
+        iters_per_stroke = int(500 / pt.m_strokes_per_block)
+        for i in range(iters_per_stroke):
+
+            pt.optimizer_x.zero_grad()
+
+            pt.x_ctt.data = torch.clamp(pt.x_ctt.data, 0.1, 1 - 0.1)
+            pt.x_color.data = torch.clamp(pt.x_color.data, 0, 1)
+            pt.x_alpha.data = torch.clamp(pt.x_alpha.data, 0, 1)
+
+            if args.canvas_color == "white":
+                pt.G_pred_canvas = torch.ones(
+                    [args.m_grid ** 2, 3, pt.net_G.out_size, pt.net_G.out_size]
+                ).to(device)
+            else:
+                pt.G_pred_canvas = torch.zeros(
+                    [args.m_grid ** 2, 3, pt.net_G.out_size, pt.net_G.out_size]
+                ).to(device)
+
+            pt._forward_pass()
+            pt._drawing_step_states()
+            pt._backward_x()
+            pt.optimizer_x.step()
+
+            pt.x_ctt.data = torch.clamp(pt.x_ctt.data, 0.1, 1 - 0.1)
+            pt.x_color.data = torch.clamp(pt.x_color.data, 0, 1)
+            pt.x_alpha.data = torch.clamp(pt.x_alpha.data, 0, 1)
+
+            pt.step_id += 1
+
+    v = pt.x.detach().cpu().numpy()
+    pt._save_stroke_params(v)
+    v_n = pt._normalize_strokes(pt.x)
+    v_n = pt._shuffle_strokes_and_reshape(v_n)
+
+    save_gif = True if output_type == "gif" else False
+    final_rendered_image, all_images = pt._render(
+        v_n, save_jpgs=False, save_video=False, save_gif=save_gif
+    )
+
+    return final_rendered_image, all_images


### PR DESCRIPTION
Hey @jiupinjia! 👋 

This pull request makes it possible to run your model inside a Docker environment, which makes it easier for other people to run it.  We're using an open source tool called [Cog](https://github.com/replicate/cog) that handles all the complex stuff like `Dockerfile`, CUDA configuration, etc.

You can run commands inside the Docker environment:

```
cog run python demo_prog.py ...
```

Or, a prediction:

```
cog predict -i image=@image.jpg
```

This also means we can make a web page where other people can try out your model! View it here: https://replicate.ai/jiupinjia/stylized-neural-painting-oil

A bit like the Runway page you already have, but you have to sign in to run models on Runway now. If you claim your page by signing in with GitHub, then we'll feature it on our site and tweet about it.

In case you're wondering who I am, I'm from [Replicate](https://replicate.ai/home), where we're trying to make machine learning reproducible. We got frustrated that we couldn't run all the really interesting ML work being done. So, we're going round implementing models we like. 😊